### PR TITLE
Accept optional command-line arguments

### DIFF
--- a/autoload/runwithme/runner.vim
+++ b/autoload/runwithme/runner.vim
@@ -3,10 +3,10 @@
 " Module containing script runner logic
 
 
-function! runwithme#runner#GetScriptCommand() abort
+function! runwithme#runner#GetScriptCommand(args) abort
   " constructs the full command to be run in the terminal
   let cmd = get(g:runner_cmds, &filetype, &filetype)
-  return cmd . ' ' . expand('%:p')
+  return cmd . ' ' . expand('%:p') . ' ' . a:args
 endfunction
 
 
@@ -45,13 +45,13 @@ function! runwithme#runner#Runner(cmd, vert) abort
 endfunction
 
 
-function! runwithme#runner#RunScript(vert) abort
+function! runwithme#runner#RunScript(args, vert) abort
   " executes current windows code in a terminal
   " a:vert (bool): 1 run in vertical terminal, 0 run in horizontal terminal
   if &filetype ==# ''
     return
   endif
-  let cmd = runwithme#runner#GetScriptCommand()
+  let cmd = runwithme#runner#GetScriptCommand(a:args)
   call runwithme#runner#Runner(cmd, a:vert)
 endfunction
 

--- a/plugin/run-with-me.vim
+++ b/plugin/run-with-me.vim
@@ -30,8 +30,8 @@ if exists('g:testing_cmds') ==# 0
 endif
 
 
-command! -nargs=* RunCode :call runwithme#runner#RunScript(0)
-command! -nargs=* RunCodeVert :call runwithme#runner#RunScript(1)
+command! -nargs=? RunCode :call runwithme#runner#RunScript(<q-args>,0)
+command! -nargs=? RunCodeVert :call runwithme#runner#RunScript(<q-args>,1)
 
 command! -range RunSelectedCode :call runwithme#runner#RunSelectedCode(0)
 command! -range RunSelectedCodeVert :call runwithme#runner#RunSelectedCode(1)


### PR DESCRIPTION
Hi, first of all, thanks for the nice plugin! 

This PR allows `RunCode` and `RunCodeVert` to accept optional command-line arguments. This way, the currently opened buffer can be executed as
```
:RunCode <args> 
```
or 
```
:RunCodeVert <args>
``` 
This could be useful in many cases. For instance, to setup a keybinding to run a script in `debug` mode or in `production` mode. These changes should be fully backward compatible, so 
```
:RunCode
```
and
```
:RunCodeVert 
```
behave exactly as they did before.